### PR TITLE
Add initial Zola homepage content

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,6 +1,10 @@
 # The URL the site will be built for
 base_url = "https://borskonomicon.github.io"
 
+title = "Borskonomicon"
+
+description = "Personal site powered by Zola"
+
 # Whether to automatically compile all Sass files in the sass directory
 compile_sass = true
 

--- a/content/_index.md
+++ b/content/_index.md
@@ -1,0 +1,9 @@
++++
+title = "Welcome to Borskonomicon"
+description = "Updates and notes about experiments, tinkering, and builds."
+paginate_by = 5
++++
+
+Hello! This site is built with [Zola](https://www.getzola.org/) and published through GitHub Pages.
+
+Expect short notes about what I am learning, experimenting with, and building. More sections will appear here as I add posts and resources.

--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,113 @@
+:root {
+    --bg: #0f172a;
+    --panel: #111827;
+    --text: #e2e8f0;
+    --muted: #94a3b8;
+    --accent: #7c3aed;
+    --accent-strong: #a855f7;
+}
+
+* {
+    box-sizing: border-box;
+}
+
+body {
+    margin: 0;
+    min-height: 100vh;
+    font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    background: radial-gradient(circle at 20% 20%, rgba(124, 58, 237, 0.08), transparent 30%),
+        radial-gradient(circle at 80% 0%, rgba(168, 85, 247, 0.1), transparent 25%),
+        var(--bg);
+    color: var(--text);
+    line-height: 1.6;
+}
+
+.container {
+    width: min(960px, 92vw);
+    margin: 0 auto;
+    padding: 0 1rem;
+}
+
+.site-header {
+    background: rgba(17, 24, 39, 0.85);
+    backdrop-filter: blur(10px);
+    border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+    position: sticky;
+    top: 0;
+    z-index: 10;
+}
+
+.site-header .container {
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+    padding: 1rem 1.2rem;
+}
+
+.site-title {
+    color: var(--text);
+    font-weight: 700;
+    font-size: 1.1rem;
+    text-decoration: none;
+    letter-spacing: 0.03em;
+}
+
+.site-title:hover {
+    color: var(--accent-strong);
+}
+
+.site-tagline {
+    margin: 0;
+    color: var(--muted);
+    font-size: 0.95rem;
+}
+
+.hero {
+    padding: 4.5rem 0 1.5rem;
+}
+
+.hero h1 {
+    margin: 0 0 0.7rem;
+    font-size: clamp(2rem, 4vw, 3rem);
+    letter-spacing: -0.01em;
+}
+
+.lede {
+    margin: 0;
+    color: var(--muted);
+    font-size: 1.1rem;
+    max-width: 52ch;
+}
+
+.content {
+    background: var(--panel);
+    border: 1px solid rgba(148, 163, 184, 0.2);
+    border-radius: 16px;
+    padding: 1.5rem;
+    box-shadow: 0 24px 60px rgba(15, 23, 42, 0.35);
+}
+
+.content p {
+    margin-top: 0;
+}
+
+.content a {
+    color: var(--accent-strong);
+    text-decoration: none;
+    border-bottom: 1px dotted rgba(124, 58, 237, 0.5);
+}
+
+.content a:hover {
+    color: #c084fc;
+    border-color: rgba(192, 132, 252, 0.8);
+}
+
+.site-footer {
+    padding: 2rem 0 3rem;
+    color: var(--muted);
+    font-size: 0.95rem;
+}
+
+.site-footer a {
+    color: var(--text);
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{% if page.title %}{{ page.title }} | {% endif %}{{ config.title }}</title>
+    <meta name="description" content="{{ page.description | default(value=config.description) }}">
+    <link rel="stylesheet" href="{{ get_url(path="style.css") }}">
+</head>
+<body>
+    <header class="site-header">
+        <div class="container">
+            <a class="site-title" href="{{ config.base_url }}">{{ config.title }}</a>
+            <p class="site-tagline">{{ config.description }}</p>
+        </div>
+    </header>
+    <main class="container">
+        {% block content %}{% endblock content %}
+    </main>
+    <footer class="site-footer">
+        <div class="container">
+            <p>Built with <a href="https://www.getzola.org/">Zola</a> and deployed via GitHub Pages.</p>
+        </div>
+    </footer>
+</body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+
+{% block content %}
+<section class="hero">
+    <h1>{{ page.title }}</h1>
+    <p class="lede">{{ page.description }}</p>
+</section>
+
+<section class="content">
+    {{ page.content | safe }}
+</section>
+{% endblock content %}


### PR DESCRIPTION
## Summary
- add a Zola-powered landing page with starter content and layout templates
- include styling for a dark-themed hero and content panel
- set site metadata for GitHub Pages builds

## Testing
- not run (zola binary unavailable in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928b94462d08330a18c638dc52f6914)