### PR TITLE
Handle section context in templates

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -3,8 +3,18 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>{% if page.title %}{{ page.title }} | {% endif %}{{ config.title }}</title>
-    <meta name="description" content="{{ page.description | default(value=config.description) }}">
+    {% if page is defined %}
+        {% set current = page %}
+    {% elif section is defined %}
+        {% set current = section %}
+    {% endif %}
+
+    <title>{% if current is defined and current.title %}{{ current.title }} | {% endif %}{{ config.title }}</title>
+    {% if current is defined and current.description %}
+        <meta name="description" content="{{ current.description }}">
+    {% else %}
+        <meta name="description" content="{{ config.description }}">
+    {% endif %}
     <link rel="stylesheet" href="{{ get_url(path="style.css") }}">
 </head>
 <body>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,12 +1,20 @@
 {% extends "base.html" %}
 
 {% block content %}
+{% if page is defined %}
+    {% set current = page %}
+{% elif section is defined %}
+    {% set current = section %}
+{% endif %}
+
 <section class="hero">
-    <h1>{{ page.title }}</h1>
-    <p class="lede">{{ page.description }}</p>
+    <h1>{{ current.title }}</h1>
+    {% if current.description %}
+        <p class="lede">{{ current.description }}</p>
+    {% endif %}
 </section>
 
 <section class="content">
-    {{ page.content | safe }}
+    {{ current.content | safe }}
 </section>
 {% endblock content %}


### PR DESCRIPTION
## Summary
- allow the base layout to derive title and description from either page or section context
- render the home page template using whichever context is available so the index section can build

## Testing
- not run (zola binary unavailable in environment; external downloads blocked)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928bb1742f08330b3a0b103ada1163c)