### PR TITLE
Fix get_url template quoting

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -16,7 +16,7 @@
     {% endif %}
     <div class="hero-actions">
         <a class="button" href="#recipes">Browse recipes</a>
-        <a class="ghost" href="{{ get_url(path="recipes/") }}">Open the catalog</a>
+        <a class="ghost" href="{{ get_url(path='recipes/') }}">Open the catalog</a>
     </div>
 </section>
 


### PR DESCRIPTION
## Summary
- correct quoting for the recipe catalog link in the index template to avoid template parsing errors

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928bdb4170883308d742e28b35f0f9c)