### PR TITLE
Fix search text construction for recipe cards

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -50,7 +50,9 @@
     <div class="recipe-grid" id="recipe-grid">
         {% for recipe in recipe_section.pages | sort(attribute="title") %}
             {% set tags = recipe.extra.tags | default(value=[]) %}
-            {% set search_text = (recipe.title ~ " " ~ (recipe.description | default(value="")) ~ " " ~ (tags | join(sep=" "))) | lower %}
+            {% set description = recipe.description | default(value="") %}
+            {% set searchable_tags = tags | join(sep=" ") %}
+            {% set search_text = (recipe.title ~ " " ~ description ~ " " ~ searchable_tags) | lower %}
             <article class="recipe-card" data-search="{{ search_text }}">
                 {% if recipe.extra.time %}
                     <p class="eyebrow">{{ recipe.extra.time }}</p>


### PR DESCRIPTION
## Summary
- simplify recipe search text generation by separating description and tag processing
- ensure search text concatenation stays on a single expression for lowercasing

## Testing
- not run (zola not available in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928be8f2a98833083d3733e14fdd21d)