### PR TITLE
Explain separation of build and deploy jobs in GitHub Pages workflow

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -16,6 +16,11 @@ concurrency:
 
 jobs:
   build:
+    # Build and deploy are kept as separate jobs because GitHub Pages expects
+    # the published artifact to come from an uploaded bundle rather than from a
+    # workspace that runs with elevated deploy permissions. This pattern limits
+    # the scope of the deploy token, makes it clear what files are deployed, and
+    # mirrors the configuration recommended in the Pages documentation.
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
- add inline documentation to the Pages workflow explaining why build and deploy remain distinct jobs
- clarify that the split aligns with GitHub Pages guidance and keeps deploy permissions scoped

## Testing
- not run (documentation-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928c17074ac8330ba703a6e0b123ded)