### PR TITLE
Refine agent guidance documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,31 @@
+# Agent Guidance
+
+These instructions are for LLM-based contributors working in this repository. They apply to all files unless a more specific `AGENTS.md` is added in a subdirectory.
+
+## Project context
+- Static recipe site built with [Zola](https://www.getzola.org/) and published via GitHub Pages.
+- Recipe content lives in `content/recipes/` as Markdown with front matter metadata.
+- The landing page surfaces recipe metadata (title, description, yield, time, tags, source link) and supports on-page search.
+
+## When adding or updating recipes
+- Create or edit a Markdown file in `content/recipes/` named for the dish (e.g., `chocolate-chip-banana-bread.md`).
+- Front matter must include:
+  - `title` (string)
+  - `description` (short summary)
+  - Optional `extra` table with `yield`, `time`, `source`, and `tags` (array).
+- Body should contain the recipe title, yield and timing details if available, an ingredients list, and step-by-step instructions.
+- Preserve ingredient amounts, units, and wording exactly as published; do not round, localize, or adjust.
+- Attribute the source in `extra.source` using the canonical URL when possible.
+
+## Accuracy checklist (follow for every recipe change)
+- Cross-check ingredient quantities against the source’s structured data (e.g., JSON-LD `recipeIngredient`) or printable card rather than prose.
+- Mirror units and temperatures exactly (cups vs. grams, °F/°C, teaspoons/tablespoons). Include ranges if present.
+- Copy prep/cook times, yields/servings, and oven temperatures verbatim from the source.
+- Preserve alternate ingredient wording (e.g., “Greek yogurt or sour cream”) without consolidation.
+- After editing, reread the source and confirm every quantity and instruction step matches.
+
+## Working practices
+- Keep README human-focused; agent-specific guidance belongs here.
+- Prefer minimal diffs: avoid reformatting unrelated text or whitespace.
+- Before committing, ensure Markdown front matter remains valid TOML and Zola-compatible.
+- If you touch templates or config, run `zola build` when feasible to catch template errors.

--- a/README.md
+++ b/README.md
@@ -13,10 +13,3 @@ The site is built with [Zola](https://www.getzola.org/) and published through Gi
 2. Add front matter with a `title`, short `description`, and optional `extra` fields like `yield`, `time`, `source`, and `tags` so the landing page can surface useful context.
 3. Include the recipe title in the front matter, then list the yield, prep/bake times if available, ingredients, and step-by-step instructions in the body of the file.
 4. Preserve ingredient amounts exactly and keep instructions clear so the recipe remains faithfully reproducible. Track the source link in `extra.source` to credit the origin.
-
-## Accuracy checklist (important for LLM agents)
-- Always cross-check the vendored ingredient amounts against the upstream source. Use the site’s JSON-LD `recipeIngredient` list (e.g., `curl -L <url> | rg -n "recipeIngredient"`) or the printable recipe card instead of guessing from prose.
-- Mirror units and weights exactly as published (cups, grams, teaspoons, etc.). Do not “improve” or round numbers.
-- Copy prep/cook times, yield/servings, and oven temperature directly from the source.
-- If the source gives alternate ingredients (e.g., Greek yogurt or sour cream), keep the wording consistent with the source.
-- After editing, reread the source to confirm every quantity and instruction step matches before committing.


### PR DESCRIPTION
## Summary
- restructure AGENTS.md with scope, project context, and clearer recipe contribution steps
- emphasize accuracy checks for ingredients, timing, and attribution pulled from source data
- add working practices to keep README human-focused and maintain valid Zola front matter

## Testing
- not run (documentation-only change)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928f4ea33b08330af8bb3e40ff90acd)