### PR TITLE
Improve source link wrapping on small screens

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -319,6 +319,7 @@ main {
 
 .source-link a {
     color: var(--accent);
+    overflow-wrap: anywhere;
 }
 
 .empty {


### PR DESCRIPTION
## Summary
- allow source links to wrap within cards to avoid overflowing on smaller screens

## Testing
- zola build *(fails: zola command not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928f83a1a388330a09e6835ff191d0b)