### PR TITLE
Add pull request build validation workflow

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -1,0 +1,22 @@
+name: Validate Pages build
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+      - name: Install Zola
+        uses: taiki-e/install-action@v2
+        with:
+          tool: zola
+      - name: Build
+        run: zola build


### PR DESCRIPTION
## Summary
- add a pull-request workflow to validate the site build
- mirror the Pages build steps by configuring Pages and installing Zola before building

## Testing
- not run (CI-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928f87628dc8330a2a606f4d92b7abd)