### PR TITLE
Update browse recipes link

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -15,7 +15,7 @@
         <p class="lede">{{ current.description }}</p>
     {% endif %}
     <div class="hero-actions">
-        <a class="button" href="#recipes">Browse recipes</a>
+        <a class="button" href="/recipes">Browse recipes</a>
     </div>
 </section>
 


### PR DESCRIPTION
## Summary
- Update the hero "Browse recipes" button to point to the /recipes page instead of the on-page anchor

## Testing
- zola build (fails: command not found: zola)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929e064b22483309e8b36d9c8022196)