### PR TITLE
Use pull_request_target for Dependabot auto-merge

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,7 +1,7 @@
 name: Dependabot auto-merge
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened]
   pull_request_review:
     types: [submitted]


### PR DESCRIPTION
## Summary
- switch Dependabot auto-merge workflow to use pull_request_target for PR events while keeping review triggers
- preserve the Dependabot actor guard and limited steps that avoid checking out untrusted code

## Testing
- not run (CI workflow change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929e082272883309e0b95dcc7156745)