### PR TITLE
Broaden Dependabot auto-merge coverage

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -22,7 +22,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Enable auto-merge for Dependabot PRs
-        if: steps.metadata.outputs.package-ecosystem == 'github-actions'
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
         uses: peter-evans/enable-pull-request-automerge@v3
         with:
           pull-request-number: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Summary
- allow Dependabot auto-merge for all ecosystems while skipping major version updates

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929e0834b70833093ae23e448fd7a4f)