### PR TITLE
Add cook mode wake lock toggle

### DIFF
--- a/static/cook-mode.js
+++ b/static/cook-mode.js
@@ -1,0 +1,50 @@
+(() => {
+    const toggle = document.querySelector('[data-cook-toggle]');
+    if (!toggle) return;
+
+    const shell = toggle.closest('.cook-mode');
+    if (!('wakeLock' in navigator)) {
+        toggle.disabled = true;
+        shell?.classList.add('is-disabled');
+        return;
+    }
+
+    let lock = null;
+
+    const requestLock = async () => {
+        if (lock) return;
+
+        try {
+            lock = await navigator.wakeLock.request('screen');
+            lock.addEventListener('release', () => {
+                lock = null;
+                toggle.checked = false;
+            });
+        } catch (err) {
+            toggle.checked = false;
+        }
+    };
+
+    const releaseLock = async () => {
+        if (!lock) return;
+        try {
+            await lock.release();
+        } finally {
+            lock = null;
+        }
+    };
+
+    toggle.addEventListener('change', () => {
+        if (toggle.checked) {
+            requestLock();
+        } else {
+            releaseLock();
+        }
+    });
+
+    document.addEventListener('visibilitychange', () => {
+        if (document.visibilityState === 'visible' && toggle.checked) {
+            requestLock();
+        }
+    });
+})();

--- a/static/style.css
+++ b/static/style.css
@@ -327,6 +327,89 @@ main {
     grid-column: 1 / -1;
 }
 
+.cook-mode {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.75rem;
+    margin-top: 1rem;
+    padding: 0.65rem 0.85rem;
+    border: 1px solid var(--border);
+    border-radius: 14px;
+    background: var(--surface);
+    box-shadow: 0 6px 16px rgba(12, 18, 27, 0.06);
+}
+
+.cook-switch {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+}
+
+.cook-switch input {
+    appearance: none;
+    width: 52px;
+    height: 30px;
+    margin: 0;
+    position: absolute;
+    inset: 0;
+    cursor: pointer;
+}
+
+.cook-track {
+    display: inline-flex;
+    align-items: center;
+    width: 52px;
+    height: 30px;
+    padding: 4px;
+    border-radius: 999px;
+    background: var(--surface-soft);
+    border: 1px solid var(--border);
+    transition: background 0.15s ease, border-color 0.15s ease;
+}
+
+.cook-thumb {
+    width: 20px;
+    height: 20px;
+    border-radius: 50%;
+    background: #d1d5db;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.12);
+    transition: transform 0.18s ease, background 0.18s ease;
+}
+
+.cook-switch input:checked + .cook-track {
+    background: var(--accent);
+    border-color: var(--accent);
+}
+
+.cook-switch input:checked + .cook-track .cook-thumb {
+    transform: translateX(22px);
+    background: #fff;
+}
+
+.cook-copy {
+    display: flex;
+    flex-direction: column;
+    gap: 0.05rem;
+}
+
+.cook-title {
+    font-weight: 600;
+    color: var(--ink);
+}
+
+.cook-help {
+    color: var(--muted);
+    font-size: 0.95rem;
+}
+
+.cook-mode.is-disabled {
+    opacity: 0.55;
+}
+
+.cook-mode.is-disabled input {
+    cursor: not-allowed;
+}
+
 .site-footer {
     padding: 1rem 0 3rem;
     color: var(--muted);

--- a/templates/page.html
+++ b/templates/page.html
@@ -25,9 +25,22 @@
     {% if page.extra.source %}
         <p class="source-link">Source: <a href="{{ page.extra.source }}" target="_blank" rel="noopener">{{ page.extra.source }}</a></p>
     {% endif %}
+
+    <div class="cook-mode">
+        <label class="cook-switch">
+            <input type="checkbox" data-cook-toggle aria-label="Toggle cook mode">
+            <span class="cook-track"><span class="cook-thumb"></span></span>
+        </label>
+        <div class="cook-copy">
+            <div class="cook-title">Cook Mode</div>
+            <div class="cook-help">Prevent your screen from going dark</div>
+        </div>
+    </div>
 </section>
 
 <section class="content">
     {{ page.content | safe }}
 </section>
+
+<script defer src="{{ get_url(path="cook-mode.js") }}"></script>
 {% endblock content %}


### PR DESCRIPTION
## Summary
- add a Cook Mode toggle to recipe pages that uses the Screen Wake Lock API to keep the display on while cooking
- style the toggle to match the site aesthetic and gracefully disable when wake locks are unsupported
- include a small script to re-request the wake lock when returning to the tab if Cook Mode is still enabled

## Testing
- Not run (zola not available in the environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f63bad1048330b0ef5b46d53dcf3a)