### PR TITLE
[codex] pin zola and update pancakes

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+PATH_add bin

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -5,9 +5,6 @@ on:
     branches: ["master"]
   workflow_dispatch:
 
-env:
-  ZOLA_VERSION: "0.21.0"
-
 permissions:
   contents: read
   pages: write
@@ -30,12 +27,8 @@ jobs:
         uses: actions/checkout@v6
       - name: Setup Pages
         uses: actions/configure-pages@v5
-      - name: Install Zola
-        uses: taiki-e/install-action@v2
-        with:
-          tool: zola@${{ env.ZOLA_VERSION }}
       - name: Build
-        run: zola build
+        run: ./bin/zola build
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v4
         with:

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -3,9 +3,6 @@ name: Validate Pages build
 on:
   pull_request:
 
-env:
-  ZOLA_VERSION: "0.21.0"
-
 permissions:
   contents: read
 
@@ -17,9 +14,5 @@ jobs:
         uses: actions/checkout@v6
       - name: Setup Pages
         uses: actions/configure-pages@v5
-      - name: Install Zola
-        uses: taiki-e/install-action@v2
-        with:
-          tool: zola@${{ env.ZOLA_VERSION }}
       - name: Build
-        run: zola build
+        run: ./bin/zola build

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 /public
-
+/.cache

--- a/README.md
+++ b/README.md
@@ -4,6 +4,16 @@ This repository collects family-favorite recipes from around the internet so the
 
 The site is built with [Zola](https://www.getzola.org/) and published through GitHub Pages. The landing page highlights the archive and includes on-page search for quickly jumping to a recipe.
 
+## Local development
+This repository pins Zola to the same version used in CI through `bin/zola`. The wrapper downloads Zola `0.21.0` into `.cache/` on first use and verifies the release checksum before running it.
+
+If you use [direnv](https://direnv.net/), run `direnv allow` once so plain `zola` resolves to the pinned wrapper. Otherwise, run commands through `./bin/zola`:
+
+```sh
+./bin/zola serve
+./bin/zola build
+```
+
 ## Repository layout
 - `content/recipes/` — individual recipe files in Markdown, each including ingredients, instructions, yield, and notes.
 - `config.toml` — site settings and metadata used during generation.

--- a/bin/zola
+++ b/bin/zola
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+version="0.21.0"
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+install_dir="${repo_root}/.cache/zola/${version}"
+zola_bin="${install_dir}/zola"
+
+if [ ! -x "${zola_bin}" ]; then
+    os="$(uname -s)"
+    arch="$(uname -m)"
+
+    case "${os}:${arch}" in
+        Darwin:arm64)
+            target="aarch64-apple-darwin"
+            expected_sha256="5fa8d33c82ee9990cb41020bff0ce40caf98fe4e46d38fdf2740a81a6c78efda"
+            ;;
+        Darwin:x86_64)
+            target="x86_64-apple-darwin"
+            expected_sha256="1bb896d52877ee637b16f6b8d5827ec1e5abbd4a78b541a771c65cebb10f47e8"
+            ;;
+        Linux:aarch64|Linux:arm64)
+            target="aarch64-unknown-linux-gnu"
+            expected_sha256="da7e9def7b9acf0c9b78fb99ce72624504cfee1066ab7a161f09a4126dd7ffe6"
+            ;;
+        Linux:x86_64)
+            target="x86_64-unknown-linux-gnu"
+            expected_sha256="5c37a8f706567d6cad3f0dbc0eaebe3b9591cc301bd67089e5ddc0d0401732d6"
+            ;;
+        *)
+            echo "Unsupported platform for pinned Zola: ${os} ${arch}" >&2
+            exit 1
+            ;;
+    esac
+
+    archive_name="zola-v${version}-${target}.tar.gz"
+    url="https://github.com/getzola/zola/releases/download/v${version}/${archive_name}"
+    tmpdir="$(mktemp -d)"
+    trap 'rm -rf "${tmpdir}"' EXIT
+
+    echo "Installing pinned Zola ${version} for ${target}..." >&2
+    curl -fsSL "${url}" -o "${tmpdir}/${archive_name}"
+
+    if command -v sha256sum >/dev/null 2>&1; then
+        actual_sha256="$(sha256sum "${tmpdir}/${archive_name}" | awk '{print $1}')"
+    else
+        actual_sha256="$(shasum -a 256 "${tmpdir}/${archive_name}" | awk '{print $1}')"
+    fi
+
+    if [ "${actual_sha256}" != "${expected_sha256}" ]; then
+        echo "Checksum mismatch for ${archive_name}" >&2
+        echo "expected: ${expected_sha256}" >&2
+        echo "actual:   ${actual_sha256}" >&2
+        exit 1
+    fi
+
+    mkdir -p "${install_dir}"
+    tar -xzf "${tmpdir}/${archive_name}" -C "${install_dir}" zola
+    chmod +x "${zola_bin}"
+fi
+
+exec "${zola_bin}" "$@"

--- a/content/recipes/chocolate-chip-pancakes.md
+++ b/content/recipes/chocolate-chip-pancakes.md
@@ -22,7 +22,7 @@ Tall, tender pancakes with crisp edges and puddles of melted chocolate in every 
 - 1 1/4 cups (295 ml) milk, room temperature
 - 1 large egg
 - 3 tablespoons (42 g) unsalted butter, melted
-- 1/3 cup (60 g) chocolate chips
+- scant 1/2 cup (75 g) chocolate chips
 
 ## Instructions
 1. In a large bowl, whisk together the flour, baking powder, salt, and sugar.
@@ -35,3 +35,7 @@ Tall, tender pancakes with crisp edges and puddles of melted chocolate in every 
 ## Notes
 - For the fluffiest pancakes, avoid overmixing; stop stirring as soon as the dry streaks disappear.
 - If the batter thickens as it rests, loosen it with a splash of milk to maintain a pourable consistency.
+
+## Nutrition Estimate
+- Serving: 1 serving | Calories: 279kcal | Carbohydrates: 38g | Protein: 8g | Fat: 12g | Saturated Fat: 7g | Fiber: 1g | Sugar: 10g
+- Calculated with Kirkland Signature all-purpose flour, organic sugar, whole milk, large egg, unsalted butter, and semi-sweet chocolate chips, plus generic baking powder; salt has no calories or macros.


### PR DESCRIPTION
## Summary

- Increase the chocolate chip amount in the pancake recipe from 60 g to 75 g and add a Kirkland-based nutrition estimate.
- Add a repo-local pinned Zola wrapper for version 0.21.0 with checksum verification.
- Route CI builds through the same wrapper and document local usage with direnv.

## Why

A local Homebrew Zola update moved the shell to Zola 0.22.1, which rejected the existing config even though CI and the devcontainer were pinned to 0.21.0. This keeps normal local development aligned with CI until the site is intentionally upgraded to the latest Zola.

## Validation

- `./bin/zola --version`
- `./bin/zola build`
- `git diff --check`