### PR TITLE
[codex] upgrade zola to 0.22.1

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:trixie-slim
 ARG USERNAME=vscode
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
-ARG ZOLA_VERSION=0.21.0
+ARG ZOLA_VERSION=0.22.1
 ARG ZOLA_ARCH=
 
 RUN set -eux; \
@@ -19,8 +19,8 @@ RUN set -eux; \
     if [ -z "${release_arch}" ]; then \
         host_arch="$(dpkg --print-architecture)"; \
         case "${host_arch}" in \
-            amd64) release_arch="x86_64-unknown-linux-musl" ;; \
-            arm64) release_arch="aarch64-unknown-linux-musl" ;; \
+            amd64) release_arch="x86_64-unknown-linux-gnu" ;; \
+            arm64) release_arch="aarch64-unknown-linux-gnu" ;; \
             *) echo "Unsupported architecture: ${host_arch}" >&2; exit 1 ;; \
         esac; \
     fi; \

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repository collects family-favorite recipes from around the internet so the
 The site is built with [Zola](https://www.getzola.org/) and published through GitHub Pages. The landing page highlights the archive and includes on-page search for quickly jumping to a recipe.
 
 ## Local development
-This repository pins Zola to the same version used in CI through `bin/zola`. The wrapper downloads Zola `0.21.0` into `.cache/` on first use and verifies the release checksum before running it.
+This repository pins Zola to the same version used in CI through `bin/zola`. The wrapper downloads Zola `0.22.1` into `.cache/` on first use and verifies the release checksum before running it.
 
 If you use [direnv](https://direnv.net/), run `direnv allow` once so plain `zola` resolves to the pinned wrapper. Otherwise, run commands through `./bin/zola`:
 

--- a/bin/zola
+++ b/bin/zola
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-version="0.21.0"
+version="0.22.1"
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 install_dir="${repo_root}/.cache/zola/${version}"
 zola_bin="${install_dir}/zola"
@@ -13,19 +13,19 @@ if [ ! -x "${zola_bin}" ]; then
     case "${os}:${arch}" in
         Darwin:arm64)
             target="aarch64-apple-darwin"
-            expected_sha256="5fa8d33c82ee9990cb41020bff0ce40caf98fe4e46d38fdf2740a81a6c78efda"
+            expected_sha256="46ac45a9e7628dba8593b124ee8794f4f9aa1c6b569918ecd4bbc5d0be190515"
             ;;
         Darwin:x86_64)
             target="x86_64-apple-darwin"
-            expected_sha256="1bb896d52877ee637b16f6b8d5827ec1e5abbd4a78b541a771c65cebb10f47e8"
+            expected_sha256="3898709e154ae0593933264a540c869348bdb10d7f1b03a42dfb78d63703b3b5"
             ;;
         Linux:aarch64|Linux:arm64)
             target="aarch64-unknown-linux-gnu"
-            expected_sha256="da7e9def7b9acf0c9b78fb99ce72624504cfee1066ab7a161f09a4126dd7ffe6"
+            expected_sha256="8af437ec6352f33ccd24d7a1cfcb54a3db95d3ce376dc69525b4ef3fb6b8c1d1"
             ;;
         Linux:x86_64)
             target="x86_64-unknown-linux-gnu"
-            expected_sha256="5c37a8f706567d6cad3f0dbc0eaebe3b9591cc301bd67089e5ddc0d0401732d6"
+            expected_sha256="0ca09aa40376aaa9ddfb512ff9ad963262ef95edb0d0f2d5ec6961b6f5cf22ef"
             ;;
         *)
             echo "Unsupported platform for pinned Zola: ${os} ${arch}" >&2

--- a/config.toml
+++ b/config.toml
@@ -11,10 +11,5 @@ compile_sass = true
 # Whether to build a search index to be used later on by a JavaScript library
 build_search_index = true
 
-[markdown]
-# Whether to do syntax highlighting
-# Theme can be customised by setting the `highlight_theme` variable to a theme supported by Zola
-highlight_code = false
-
 [extra]
 # Put all your custom variables here


### PR DESCRIPTION
## Summary

- Upgrade the pinned Zola wrapper from 0.21.0 to 0.22.1 using the official release artifact checksums.
- Update the devcontainer default Zola version to 0.22.1 and use available GNU Linux release targets.
- Remove the obsolete `markdown.highlight_code` config setting that Zola 0.22.1 rejects.
- Update local development docs to name the new pinned version.

## Why

Zola 0.22.x changed syntax highlighting configuration. This site had highlighting disabled through the old `highlight_code = false` setting, so the migration is to drop that obsolete setting and use the default no-highlighting behavior.

## Validation

- `./bin/zola --version`
- `./bin/zola build`
- `zola build`
- `bash -n bin/zola`
- `git diff --check`

Docker is not available in this local environment, so the devcontainer build is left to CI.