### PR TITLE
Align pancake chocolate chip nutrition

### DIFF
--- a/content/recipes/chocolate-chip-pancakes.md
+++ b/content/recipes/chocolate-chip-pancakes.md
@@ -23,7 +23,7 @@ Tall, tender pancakes with crisp edges and puddles of melted chocolate in every 
 - 1 large egg
 - 3 tablespoons (42 g) unsalted butter, melted
 - 1/2 teaspoon vanilla
-- 1/2 cup (75 g) chocolate chips
+- 1/2 cup (84 g) chocolate chips
 
 ## Instructions
 1. In a large bowl, whisk together the flour, baking powder, salt, and sugar.
@@ -38,5 +38,5 @@ Tall, tender pancakes with crisp edges and puddles of melted chocolate in every 
 - If the batter thickens as it rests, loosen it with a splash of milk to maintain a pourable consistency.
 
 ## Nutrition Estimate
-- Serving: 1 serving | Calories: 279kcal | Carbohydrates: 38g | Protein: 8g | Fat: 12g | Saturated Fat: 7g | Fiber: 1g | Sugar: 10g
-- Calculated with Kirkland Signature all-purpose flour, organic sugar, whole milk, large egg, unsalted butter, and semi-sweet chocolate chips, plus generic baking powder; salt has no calories or macros.
+- Serving: 1 serving | Calories: 285kcal | Carbohydrates: 39g | Protein: 8g | Fat: 12g | Saturated Fat: 7g | Fiber: 1g | Sugar: 11g
+- Calculated with Kirkland Signature all-purpose flour, organic sugar, whole milk, large egg, unsalted butter, and 1/2 cup (84 g) semi-sweet chocolate chips, plus generic baking powder; salt has no calories or macros.

--- a/content/recipes/chocolate-chip-pancakes.md
+++ b/content/recipes/chocolate-chip-pancakes.md
@@ -38,5 +38,5 @@ Tall, tender pancakes with crisp edges and puddles of melted chocolate in every 
 - If the batter thickens as it rests, loosen it with a splash of milk to maintain a pourable consistency.
 
 ## Nutrition Estimate
-- Serving: 1 serving | Calories: 285kcal | Carbohydrates: 39g | Protein: 8g | Fat: 12g | Saturated Fat: 7g | Fiber: 1g | Sugar: 11g
+- Serving: 1/6 of recipe | Calories: 285kcal | Carbohydrates: 39g | Protein: 8g | Fat: 12g | Saturated Fat: 7g | Fiber: 1g | Sugar: 11g
 - Calculated with Kirkland Signature all-purpose flour, organic sugar, whole milk, large egg, unsalted butter, and 1/2 cup (84 g) semi-sweet chocolate chips, plus generic baking powder; salt has no calories or macros.


### PR DESCRIPTION
Follow-up to #34.

The previous wording-only change left the pancake page internally inconsistent by keeping the old `75 g` parenthetical and nutrition estimate after changing the chip quantity to `1/2 cup`.

This follow-up keeps the archived recipe wording intact while making the page self-consistent:
- updates `1/2 cup` chocolate chips to `1/2 cup (84 g)`
- updates the nutrition estimate to match the larger chocolate chip amount
- updates the nutrition note to match the revised ingredient amount